### PR TITLE
Remove ':' from line separating module comment from array_is_nonempty() c

### DIFF
--- a/modules/bash/array/dsl
+++ b/modules/bash/array/dsl
@@ -3,7 +3,7 @@
 #
 # # Array Module
 #
-:
+
 #
 # ## array\_is\_nonempty()
 #


### PR DESCRIPTION
Remove ':' from line separating module comment from array_is_nonempty() comments
