### PR TITLE
Fix installation as user

### DIFF
--- a/extensions/builtin/core/modules/shell/dsl
+++ b/extensions/builtin/core/modules/shell/dsl
@@ -332,7 +332,7 @@ install_core()
 
 install_configuration_files()
 {
-  log "  Ensuring that the configuration files (${configs[*]}) exist in ${config_path}"
+  log "  Ensuring that the configuration files (${configs[*]}) exist in ${install_path}"
   for config_file in "${configs[@]}"
   do
     ensure_files_exist "${install_path}/config/${config_file}"


### PR DESCRIPTION
There is a typo preventing the installation to finish successfully:

```
Installing BDSM Framework into /home/romain/.bdsm

  Ensuring that install_path '/home/romain/.bdsm' exists
  Cleansing installation path
  Creating installation paths
  Installing core directories (bin completion) into /home/romain/.bdsm
  Installing core files (LICENSE VERSION README.md) into /home/romain/.bdsm
  Installing builtin extensions
  Installing internal extensions
  fetching wayneeseguin/bdsm-extensions to /home/romain/.bdsm/src/wayneeseguin_bdsm-extensions
  Migrating external extensions
  Ensuring that the configuration files (user) exist in /usr/local/bdsm/extensions/builtin/core/config
  Linking /home/romain/.bdsm/bin/bdsm to /home/romain/bin/bdsm
mkdir: /usr/local/bdsm: Permission denied
```

The fix is trivial.
