### PR TITLE
Fail gracefully without zsh installed.

### DIFF
--- a/install
+++ b/install
@@ -2,6 +2,12 @@
 
 extension_args=()
 
+if [[ ! -e "/bin/zsh" ]]
+then
+  echo "ERROR: /bin/zsh required for SM."
+  exit 1
+fi
+
 while (( $# ))
 do
   token="$1" && shift


### PR DESCRIPTION
I was working on a very bare vagrant image that didn't have zsh installed.

This adds a friendly error rather than a cryptic 'bad interpreter' message during install.
