### PR TITLE
Use bash as shell for bash completion

### DIFF
--- a/bin/sm-completion
+++ b/bin/sm-completion
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 
 # usage: complete -C sm-completion sm
 sm --call=api/extensions/completion/extension_action_completion -- "${COMP_LINE:0:COMP_POINT}"


### PR DESCRIPTION
Bash completion with sm-completion works only if the shell that runs the
script itself is bash, when sh or zsh are used completion fails silently
or with errors.
