### PR TITLE
When parsing the ruby shebang, escape the '#'

### DIFF
--- a/core/internal/shell/extensions/execution/functions
+++ b/core/internal/shell/extensions/execution/functions
@@ -43,7 +43,7 @@ __sm.extension.actions.type()
 
           case "${shebang}" in
             *ruby|*rbx|*jruby|*macruby)
-              binary="${shebang##*(#|!)}"
+              binary="${shebang##*(\#|!)}"
               binary="${binary##* }"
               action_type="ruby"
               ;;


### PR DESCRIPTION
Escape the hash in the shell pattern when parsing the shebang.
Used for the ruby shebang '#!/usr/bin/env ruby' for example.

I was following drnic's https://github.com/drnic/bosh-solo#full-tutorial-on-remote-vm
on a new ubuntu-12.04 VM.

```
sm ext bosh-solo status
```

did not work and logged a few 

```
__sm.extension.actions.type:43: bad pattern: *(#|!)
```

After some debugging, escaping the '#' seemed to get passed that issue.
It is also consistent with all the other pattern in that part of the code where the # is escaped.

I was not able to reproduce the issue with a simple script:

```
shebang='#!/usr/bin/env ruby'
case "${shebang}" in
    *ruby|*rbx|*jruby|*macruby)
    binary="${shebang##*(\#|!)}"
```

works both with the escaped and none escaped #.
So I still have a doubt whether this is really necessary outside of my setup.

Let me know if you want further investigation.
Thanks for your attention.
