### PR TITLE
Tweaks for ubuntu precise

### DIFF
--- a/core/internal/shell/extensions/execution/functions
+++ b/core/internal/shell/extensions/execution/functions
@@ -191,7 +191,10 @@ __sm.extension.run()
       requires=()
       for script in functions initialize
       do
-        requires+=( "-r${__sm_modules_path}/ruby/core/${script}.rb" )
+        if [[ -f "${__sm_modules_path}/ruby/core/${script}.rb" ]]
+        then
+          requires+=( "-r${__sm_modules_path}/ruby/core/${script}.rb" )
+        fi
       done
 
       exec "${binary:-ruby}" -I"${__sm_modules_path}/ruby" -I"${extension_modules_path}/ruby" \


### PR DESCRIPTION
Thanks Michal for looking after the shebang.

I am getting further errors when running on ubuntu-12.04 (aka precise)
The reason is that the `file` command does not return the same text on ubuntu-10.10 (aka lucid)

Here is the file:

```
root@lucid64:/vagrant# ll /opt/sm/exts/active/bosh-solo/bin/status
-rwxr-xr-x 1 root root 498 2012-08-22 02:27 /opt/sm/exts/active/bosh-solo/bin/status*
root@lucid64:/vagrant# cat /opt/sm/exts/active/bosh-solo/bin/status | head -1
#!/usr/bin/env ruby
```

On lucid64, the file command returns:

```
root@lucid64:/vagrant# file /opt/sm/exts/active/bosh-solo/bin/status
/opt/sm/exts/active/bosh-solo/bin/status: a ruby script text executable
```

On precise64:

```
root@precise64:/vagrant# file /opt/sm/exts/active/bosh-solo/bin/status
/opt/sm/exts/active/bosh-solo/bin/status: a ruby script, ASCII text executable
```

As a consequence; on lucid64, bosh-solo status's action_type is  "binary"
where as on precise64, it is "ruby".
This explains the difference of treatment and why on lucid64 we did not see the shebang issue reported in pull 48.

The next problem is this block of code around line 188 https://github.com/sm/sm/blob/master/core/internal/shell/extensions/execution/functions#L188:

```
(ruby)
 ... for script in functions initialize
 do
    requires+=( "-r${__sm_modules_path}/ruby/core/${script}.rb" )
 done
```

It is not executed on lucid64; on precise64, it is executed and looks for the files:
/opt/sm/core/sm/shell/ruby/core/functions.rb
/opt/sm/core/sm/shell/ruby/core/initialize.rb

Both of which do not exist.
For now I have added a guard to check if they exist and silently skip them if they don't.

After that `sm bosh-solo status`  works fine on precise.

Thanks again for your attention!
