### PR TITLE
Updated manual url in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ progress. Suggestions on improving the manual are most welcome.
 
 The latest version of the manual is kept at the following url:
 
-    https://smf.sh/sm-manual.pdf
+    https://smf.sh/docs/sm-manual.pdf
 
 Anytime updates are made to the manual a new version is pushed to that url.
 


### PR DESCRIPTION
the previous url redirected to the homepage of SM, the new one points to the real manual in PDF format.
